### PR TITLE
feat: domain + recipient routing hook

### DIFF
--- a/solidity/contracts/hooks/routing/DomainRecipientRoutingHook.sol
+++ b/solidity/contracts/hooks/routing/DomainRecipientRoutingHook.sol
@@ -21,6 +21,7 @@ import {IPostDispatchHook} from "../../interfaces/hooks/IPostDispatchHook.sol";
 
 // ============ External Imports ============
 import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {TypeCasts} from "../../libs/TypeCasts.sol";
 
 /**
  * @title DomainRecipientRoutingHook
@@ -30,6 +31,7 @@ import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 contract DomainRecipientRoutingHook is AbstractPostDispatchHook, MailboxClient {
     using Strings for uint32;
     using Message for bytes;
+    using TypeCasts for bytes32;
 
     struct HookConfig {
         uint32 destination;
@@ -111,7 +113,7 @@ contract DomainRecipientRoutingHook is AbstractPostDispatchHook, MailboxClient {
         bytes calldata message
     ) internal view virtual returns (IPostDispatchHook hook) {
         uint32 destination = message.destination();
-        address recipient = message.recipient();
+        address recipient = message.recipient().bytes32ToAddress();
 
         hook = hooks[destination][recipient];
         if (address(hook) == address(0)) {

--- a/solidity/contracts/hooks/routing/DomainRecipientRoutingHook.sol
+++ b/solidity/contracts/hooks/routing/DomainRecipientRoutingHook.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+// ============ Internal Imports ============
+import {AbstractPostDispatchHook} from "../libs/AbstractPostDispatchHook.sol";
+import {MailboxClient} from "../../client/MailboxClient.sol";
+import {Message} from "../../libs/Message.sol";
+import {IPostDispatchHook} from "../../interfaces/hooks/IPostDispatchHook.sol";
+
+// ============ External Imports ============
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+/**
+ * @title DomainRecipientRoutingHook
+ * @notice Delegates to a hook based on both the destination domain and recipient of the message.
+ * @dev Uses a composite key of domain and recipient to route messages to specific hooks.
+ */
+contract DomainRecipientRoutingHook is AbstractPostDispatchHook, MailboxClient {
+    using Strings for uint32;
+    using Message for bytes;
+
+    struct HookConfig {
+        uint32 destination;
+        address recipient;
+        address hook;
+    }
+
+    // Mapping of domain and recipient to hook
+    mapping(uint32 => mapping(address => IPostDispatchHook)) public hooks;
+
+    constructor(address _mailbox, address _owner) MailboxClient(_mailbox) {
+        _transferOwnership(_owner);
+    }
+
+    // ============ External Functions ============
+
+    /// @inheritdoc IPostDispatchHook
+    function hookType() external pure virtual override returns (uint8) {
+        return uint8(IPostDispatchHook.Types.ROUTING);
+    }
+
+    /**
+     * @notice Sets a hook for a specific domain and recipient combination
+     * @param _destination The destination domain
+     * @param _recipient The recipient address
+     * @param _hook The hook address to use
+     */
+    function setHook(
+        uint32 _destination,
+        address _recipient,
+        address _hook
+    ) public onlyOwner {
+        hooks[_destination][_recipient] = IPostDispatchHook(_hook);
+    }
+
+    /**
+     * @notice Sets multiple hooks at once
+     * @param configs Array of hook configurations
+     */
+    function setHooks(HookConfig[] calldata configs) external onlyOwner {
+        for (uint256 i = 0; i < configs.length; i++) {
+            setHook(
+                configs[i].destination,
+                configs[i].recipient,
+                configs[i].hook
+            );
+        }
+    }
+
+    function supportsMetadata(
+        bytes calldata
+    ) public pure virtual override returns (bool) {
+        // routing hook does not care about metadata shape
+        return true;
+    }
+
+    // ============ Internal Functions ============
+
+    /// @inheritdoc AbstractPostDispatchHook
+    function _postDispatch(
+        bytes calldata metadata,
+        bytes calldata message
+    ) internal virtual override {
+        _getConfiguredHook(message).postDispatch{value: msg.value}(
+            metadata,
+            message
+        );
+    }
+
+    /// @inheritdoc AbstractPostDispatchHook
+    function _quoteDispatch(
+        bytes calldata metadata,
+        bytes calldata message
+    ) internal view virtual override returns (uint256) {
+        return _getConfiguredHook(message).quoteDispatch(metadata, message);
+    }
+
+    function _getConfiguredHook(
+        bytes calldata message
+    ) internal view virtual returns (IPostDispatchHook hook) {
+        uint32 destination = message.destination();
+        address recipient = message.recipient();
+
+        hook = hooks[destination][recipient];
+        if (address(hook) == address(0)) {
+            revert(
+                string.concat(
+                    "No hook configured for destination: ",
+                    destination.toString(),
+                    " and recipient: ",
+                    Strings.toHexString(uint160(recipient), 20)
+                )
+            );
+        }
+    }
+}

--- a/solidity/contracts/hooks/routing/FallbackDomainRecipientRoutingHook.sol
+++ b/solidity/contracts/hooks/routing/FallbackDomainRecipientRoutingHook.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.8.0;
+
+/*@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+     @@@@@  HYPERLANE  @@@@@@@
+    @@@@@@@@@@@@@@@@@@@@@@@@@
+   @@@@@@@@@       @@@@@@@@@
+  @@@@@@@@@       @@@@@@@@@
+ @@@@@@@@@       @@@@@@@@@
+@@@@@@@@@       @@@@@@@@*/
+
+import {IPostDispatchHook} from "../../interfaces/hooks/IPostDispatchHook.sol";
+import {DomainRecipientRoutingHook} from "./DomainRecipientRoutingHook.sol";
+import {Message} from "../../libs/Message.sol";
+
+/**
+ * @title FallbackDomainRecipientRoutingHook
+ * @notice Delegates to a hook based on both the destination domain and recipient of the message.
+ * If no hook is configured for the specific domain+recipient combination, delegates to a fallback hook.
+ */
+contract FallbackDomainRecipientRoutingHook is DomainRecipientRoutingHook {
+    using Message for bytes;
+
+    IPostDispatchHook public immutable fallbackHook;
+
+    constructor(
+        address _mailbox,
+        address _owner,
+        address _fallback
+    ) DomainRecipientRoutingHook(_mailbox, _owner) {
+        fallbackHook = IPostDispatchHook(_fallback);
+    }
+
+    // ============ External Functions ============
+
+    /// @inheritdoc IPostDispatchHook
+    function hookType() external pure override returns (uint8) {
+        return uint8(IPostDispatchHook.Types.FALLBACK_ROUTING);
+    }
+
+    // ============ Internal Functions ============
+
+    function _getConfiguredHook(
+        bytes calldata message
+    ) internal view override returns (IPostDispatchHook) {
+        IPostDispatchHook _hook = hooks[message.destination()][
+            message.recipient()
+        ];
+        if (address(_hook) == address(0)) {
+            _hook = fallbackHook;
+        }
+        return _hook;
+    }
+}

--- a/solidity/contracts/hooks/routing/FallbackDomainRecipientRoutingHook.sol
+++ b/solidity/contracts/hooks/routing/FallbackDomainRecipientRoutingHook.sol
@@ -16,6 +16,7 @@ pragma solidity >=0.8.0;
 import {IPostDispatchHook} from "../../interfaces/hooks/IPostDispatchHook.sol";
 import {DomainRecipientRoutingHook} from "./DomainRecipientRoutingHook.sol";
 import {Message} from "../../libs/Message.sol";
+import {TypeCasts} from "../../libs/TypeCasts.sol";
 
 /**
  * @title FallbackDomainRecipientRoutingHook
@@ -24,6 +25,7 @@ import {Message} from "../../libs/Message.sol";
  */
 contract FallbackDomainRecipientRoutingHook is DomainRecipientRoutingHook {
     using Message for bytes;
+    using TypeCasts for bytes32;
 
     IPostDispatchHook public immutable fallbackHook;
 
@@ -47,9 +49,10 @@ contract FallbackDomainRecipientRoutingHook is DomainRecipientRoutingHook {
     function _getConfiguredHook(
         bytes calldata message
     ) internal view override returns (IPostDispatchHook) {
-        IPostDispatchHook _hook = hooks[message.destination()][
-            message.recipient()
-        ];
+        uint32 destination = message.destination();
+        address recipient = message.recipient().bytes32ToAddress();
+
+        IPostDispatchHook _hook = hooks[destination][recipient];
         if (address(_hook) == address(0)) {
             _hook = fallbackHook;
         }

--- a/solidity/test/hooks/DomainRecipientRoutingHook.t.sol
+++ b/solidity/test/hooks/DomainRecipientRoutingHook.t.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: Apache-1.0
+pragma solidity ^0.8.13;
+
+import "forge-std/Test.sol";
+
+import {TypeCasts} from "../../contracts/libs/TypeCasts.sol";
+import {DomainRecipientRoutingHook} from "../../contracts/hooks/routing/DomainRecipientRoutingHook.sol";
+import {FallbackDomainRecipientRoutingHook} from "../../contracts/hooks/routing/FallbackDomainRecipientRoutingHook.sol";
+import {TestPostDispatchHook} from "../../contracts/test/TestPostDispatchHook.sol";
+import {TestMailbox} from "../../contracts/test/TestMailbox.sol";
+import {IPostDispatchHook} from "../../contracts/interfaces/hooks/IPostDispatchHook.sol";
+
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+
+contract DomainRecipientRoutingHookTest is Test {
+    using Strings for uint32;
+    using TypeCasts for address;
+
+    DomainRecipientRoutingHook public hook;
+    TestPostDispatchHook public noopHook;
+    TestMailbox public mailbox;
+
+    function setUp() public virtual {
+        address owner = address(this);
+        uint32 origin = 0;
+        mailbox = new TestMailbox(origin);
+        hook = new DomainRecipientRoutingHook(address(mailbox), owner);
+        noopHook = new TestPostDispatchHook();
+    }
+
+    function test_quoteDispatch(
+        uint32 destination,
+        address recipient,
+        bytes memory body,
+        bytes memory metadata,
+        uint256 fee
+    ) public {
+        vm.assume(recipient != address(0));
+        noopHook.setFee(fee);
+
+        hook.setHook(destination, recipient, address(noopHook));
+
+        bytes memory testMessage = mailbox.buildOutboundMessage(
+            destination,
+            recipient.addressToBytes32(),
+            body
+        );
+
+        vm.expectCall(
+            address(noopHook),
+            abi.encodeCall(noopHook.quoteDispatch, (metadata, testMessage))
+        );
+        assertEq(hook.quoteDispatch(metadata, testMessage), fee);
+    }
+
+    function test_quoteDispatch_whenDestinationRecipientUnenrolled(
+        uint32 destination,
+        address recipient,
+        bytes memory body,
+        bytes memory metadata
+    ) public {
+        vm.assume(recipient != address(0));
+        bytes memory testMessage = mailbox.buildOutboundMessage(
+            destination,
+            recipient.addressToBytes32(),
+            body
+        );
+        // dynamic reason cannot be checked?
+        vm.expectRevert();
+        hook.quoteDispatch(metadata, testMessage);
+    }
+
+    function test_postDispatch(
+        uint32 destination,
+        address recipient,
+        bytes memory body,
+        bytes memory metadata
+    ) public {
+        vm.assume(recipient != address(0));
+        hook.setHook(destination, recipient, address(noopHook));
+
+        bytes memory testMessage = mailbox.buildOutboundMessage(
+            destination,
+            recipient.addressToBytes32(),
+            body
+        );
+
+        vm.expectCall(
+            address(noopHook),
+            abi.encodeCall(noopHook.postDispatch, (metadata, testMessage))
+        );
+        hook.postDispatch(metadata, testMessage);
+    }
+
+    function test_postDispatch_whenDestinationRecipientUnenrolled(
+        uint32 destination,
+        address recipient,
+        bytes memory body,
+        bytes memory metadata
+    ) public virtual {
+        vm.assume(recipient != address(0));
+        bytes memory testMessage = mailbox.buildOutboundMessage(
+            destination,
+            recipient.addressToBytes32(),
+            body
+        );
+        // dynamic reason cannot be checked?
+        vm.expectRevert();
+        hook.postDispatch(metadata, testMessage);
+    }
+
+    function testHookType() public virtual {
+        assertEq(hook.hookType(), uint8(IPostDispatchHook.Types.ROUTING));
+    }
+
+    function test_setHooks(
+        uint32[] memory destinations,
+        address[] memory recipients,
+        address[] memory hooks
+    ) public {
+        vm.assume(
+            destinations.length > 0 &&
+                destinations.length == recipients.length &&
+                destinations.length == hooks.length
+        );
+
+        // Create configs array
+        DomainRecipientRoutingHook.HookConfig[]
+            memory configs = new DomainRecipientRoutingHook.HookConfig[](
+                destinations.length
+            );
+
+        for (uint256 i = 0; i < destinations.length; i++) {
+            vm.assume(recipients[i] != address(0));
+            configs[i] = DomainRecipientRoutingHook.HookConfig({
+                destination: destinations[i],
+                recipient: recipients[i],
+                hook: hooks[i]
+            });
+        }
+
+        hook.setHooks(configs);
+
+        // Verify each hook was set correctly
+        for (uint256 i = 0; i < destinations.length; i++) {
+            assertEq(
+                address(hook.hooks(destinations[i], recipients[i])),
+                hooks[i]
+            );
+        }
+    }
+}
+
+contract FallbackDomainRecipientRoutingHookTest is
+    DomainRecipientRoutingHookTest
+{
+    using TypeCasts for address;
+
+    TestPostDispatchHook public fallbackHook;
+
+    function setUp() public override {
+        address owner = address(this);
+        uint32 origin = 0;
+        mailbox = new TestMailbox(origin);
+        fallbackHook = new TestPostDispatchHook();
+        noopHook = new TestPostDispatchHook();
+        hook = new FallbackDomainRecipientRoutingHook(
+            address(mailbox),
+            owner,
+            address(fallbackHook)
+        );
+    }
+
+    function test_quoteDispatch_whenDestinationRecipientUnenrolled(
+        uint32 destination,
+        address recipient,
+        bytes memory body,
+        bytes memory metadata,
+        uint256 fee
+    ) public {
+        vm.assume(recipient != address(0));
+        fallbackHook.setFee(fee);
+
+        bytes memory testMessage = mailbox.buildOutboundMessage(
+            destination,
+            recipient.addressToBytes32(),
+            body
+        );
+
+        vm.expectCall(
+            address(fallbackHook),
+            abi.encodeCall(fallbackHook.quoteDispatch, (metadata, testMessage))
+        );
+        assertEq(hook.quoteDispatch(metadata, testMessage), fee);
+    }
+
+    function test_postDispatch_whenDestinationRecipientUnenrolled(
+        uint32 destination,
+        address recipient,
+        bytes memory body,
+        bytes memory metadata
+    ) public override {
+        vm.assume(recipient != address(0));
+        bytes memory testMessage = mailbox.buildOutboundMessage(
+            destination,
+            recipient.addressToBytes32(),
+            body
+        );
+
+        vm.expectCall(
+            address(fallbackHook),
+            abi.encodeCall(fallbackHook.postDispatch, (metadata, testMessage))
+        );
+        hook.postDispatch(metadata, testMessage);
+    }
+
+    function testHookType() public override {
+        assertEq(
+            hook.hookType(),
+            uint8(IPostDispatchHook.Types.FALLBACK_ROUTING)
+        );
+    }
+}


### PR DESCRIPTION
### Description

Adds a routing hook for (domainID, recipient) tuples. 

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
